### PR TITLE
Update travis to Xcode 9.3 and fix deprecation warning.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ notifications:
   email:
   - apple.builds@sagebase.org
 language: objective-c
-osx_image: xcode9.2
+osx_image: xcode9.3
 xcode_project: mPower2/mPower2.xcodeproj
 xcode_scheme: mPower2
 cache:

--- a/mPower2/MotorControl/ViewControllers/MCTInstructionStepViewController.swift
+++ b/mPower2/MotorControl/ViewControllers/MCTInstructionStepViewController.swift
@@ -63,7 +63,7 @@ extension MCTHandStepController {
         repeat {
             if let handSelectionResult = taskPath?.result.findResult(with: MCTHandSelectionDataSource.selectionKey) as? RSDCollectionResult,
                let handOrder : [String] = handSelectionResult.findAnswerResult(with: MCTHandSelectionDataSource.handOrderKey)?.value as? [String] {
-               return handOrder.flatMap{ MCTHandSelection(rawValue: $0) }
+                return handOrder.compactMap{ MCTHandSelection(rawValue: $0) }
             }
         
             taskPath = taskPath?.parentPath


### PR DESCRIPTION
Use Xcode 9.3 to build using travis.

Note: Will need a second PR to add a test app that can run the unit tests since mPower requires a secret code in a different repo.