### PR TITLE
Update the walk-and-balance and tremor navigation

### DIFF
--- a/mPower2/MotorControl/Resources/ActiveTaskSteps.storyboard
+++ b/mPower2/MotorControl/Resources/ActiveTaskSteps.storyboard
@@ -325,7 +325,7 @@
                                 <rect key="frame" x="49.5" y="157.5" width="222" height="222"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SECONDS" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4Gl-I3-Byg" userLabel="Unit Label">
-                                        <rect key="frame" x="73.5" y="157" width="75" height="19.5"/>
+                                        <rect key="frame" x="72.5" y="157" width="75" height="19.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <nil key="highlightedColor"/>
@@ -377,9 +377,6 @@
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="boolean" keyPath="isSecondaryButton" value="YES"/>
                                 </userDefinedRuntimeAttributes>
-                                <connections>
-                                    <action selector="restartButtonTapped:" destination="kx5-nS-n0F" eventType="touchUpInside" id="aK5-8q-QKh"/>
-                                </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xlT-Pj-FXY" userLabel="Review Button" customClass="RSDUnderlinedButton" customModule="ResearchUI">
                                 <rect key="frame" x="85.5" y="505.5" width="149" height="32.5"/>
@@ -423,14 +420,14 @@
                         <connections>
                             <outlet property="cancelButton" destination="a9L-sM-gnJ" id="MT1-cq-JgO"/>
                             <outlet property="imageView" destination="Z9U-qL-Bij" id="ryn-uZ-yUd"/>
+                            <outlet property="learnMoreButton" destination="xlT-Pj-FXY" id="kVE-3Y-FmK"/>
+                            <outlet property="skipButton" destination="a9c-PV-TEq" id="qAo-hZ-mc4"/>
                             <outlet property="titleLabel" destination="Kqn-vH-L1X" id="6QI-wl-HKA"/>
                         </connections>
                     </view>
                     <connections>
                         <outlet property="countdownDial" destination="CRK-Yd-4Pa" id="2Dh-85-TAK"/>
                         <outlet property="countdownLabel" destination="OoL-gH-k3I" id="1d8-Bi-iW4"/>
-                        <outlet property="navigationHeader" destination="mlx-p8-ccw" id="Tar-BD-bWd"/>
-                        <outlet property="restartButton" destination="a9c-PV-TEq" id="ScN-Zz-O3d"/>
                         <outlet property="statusBarBackgroundView" destination="AQ2-43-2k3" id="WJC-SY-FIR"/>
                         <outlet property="unitLabel" destination="4Gl-I3-Byg" id="yfX-kv-8gw"/>
                     </connections>
@@ -442,7 +439,7 @@
         <!--Countdown Step View Controller-->
         <scene sceneID="SB1-Dp-A6s">
             <objects>
-                <viewController storyboardIdentifier="Countdown" id="DiW-Sz-hwr" customClass="RSDCountdownStepViewController" customModule="ResearchUI" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="Countdown" id="DiW-Sz-hwr" customClass="MCTCountdownStepViewController" customModule="MotorControl" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="GS6-LM-X1w" customClass="RSDStepHeaderView" customModule="ResearchUI">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -524,12 +521,12 @@
                         <connections>
                             <outlet property="cancelButton" destination="5aE-sq-nnA" id="Nj8-tY-RPt"/>
                             <outlet property="imageView" destination="ePz-9Y-VGg" id="ocU-eT-z7M"/>
+                            <outlet property="learnMoreButton" destination="4ph-h6-gCc" id="h1e-7e-4E6"/>
                             <outlet property="textLabel" destination="9un-Qi-dJY" id="HWg-F6-vS8"/>
                         </connections>
                     </view>
                     <connections>
                         <outlet property="countdownLabel" destination="aga-Uj-SL9" id="EgC-Wk-4IR"/>
-                        <outlet property="navigationHeader" destination="GS6-LM-X1w" id="t8J-ZS-sOm"/>
                         <outlet property="pauseButton" destination="9Qh-cg-kfP" id="Xzj-75-aMt"/>
                         <outlet property="statusBarBackgroundView" destination="G2D-5j-sDp" id="Pzl-58-s9e"/>
                     </connections>
@@ -918,9 +915,6 @@
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="boolean" keyPath="isSecondaryButton" value="YES"/>
                                 </userDefinedRuntimeAttributes>
-                                <connections>
-                                    <action selector="restartButtonTapped:" destination="kx5-nS-n0F" eventType="touchUpInside" id="a6M-Nz-mfp"/>
-                                </connections>
                             </button>
                         </subviews>
                         <color key="backgroundColor" red="0.32568424940000001" green="0.25694268939999998" blue="0.52321022750000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/mPower2/MotorControl/Resources/TremorSectionStep.json
+++ b/mPower2/MotorControl/Resources/TremorSectionStep.json
@@ -54,8 +54,14 @@
                   "commands":["transitionAutomatically", "shouldDisableIdleTimer", "vibrate", "playSound"],
                   "actions":{
                       "skip":{
-                          "skipToIdentifier":"countdown",
+                          "type":"navigation",
+                          "skipToIdentifier":"tremor",
                           "buttonTitle": "Restart test"
+                      },
+                      "learnMore":{
+                          "type":"navigation",
+                          "skipToIdentifier": "holdPhoneInstructions",
+                          "buttonTitle": "Review instructions"
                       }
                   },
                   "title": "Hold the phone still in your %@ hand.",

--- a/mPower2/MotorControl/Resources/Walk_And_Balance.json
+++ b/mPower2/MotorControl/Resources/Walk_And_Balance.json
@@ -160,44 +160,38 @@
                  }
              },
              {
+                 "identifier":"countdown.1",
+                 "type":"countdown",
+                 "text":"Begin in...",
+                 "image":{
+                     "imageName":"F-Walking1",
+                     "placementType":"fullsizeBackground"
+                 },
+                 "viewTheme":{
+                     "viewIdentifier":"Countdown",
+                     "storyboardIdentifier":"ActiveTaskSteps"
+                 },
+                 "colorTheme":{
+                     "usesLightStyle":true
+                 },
+                 "duration":5,
+                 "commands":["playSoundOnStart", "transitionAutomatically"],
+                 "spokenInstructions":{
+                     "start":"Place the phone in your pocket."
+                 }
+             },
+             {
                  "identifier":"walk",
                  "type":"section",
                  "asyncActions":[
                                  {
                                      "identifier":"motion",
                                      "type":"motion",
-                                     "startStepIdentifier":"countdown",
                                      "requiresBackgroundAudio":true,
                                      "recorderTypes":["accelerometer", "gyro"]
                                  }
                                 ],
                  "steps":[
-                          {
-                              "identifier":"countdown",
-                              "type":"countdown",
-                              "text":"Begin in...",
-                              "image":{
-                                  "imageName":"F-Walking1",
-                                  "placementType":"fullsizeBackground"
-                              },
-                              "viewTheme":{
-                                  "viewIdentifier":"Countdown",
-                                  "storyboardIdentifier":"ActiveTaskSteps"
-                              },
-                              "colorTheme":{
-                                  "usesLightStyle":true
-                              },
-                              "duration":5,
-                              "commands":["playSoundOnStart", "transitionAutomatically"],
-                              "spokenInstructions":{
-                                  "start":"Place the phone in your pocket."
-                              },
-                              "actions":{
-                                  "skip":{
-                                      "skipToIdentifier":"countdown"
-                                  }
-                              }
-                          },
                           {
                               "identifier":"motion",
                               "type":"active",
@@ -213,6 +207,18 @@
                               "viewTheme":{
                                   "viewIdentifier":"Action",
                                   "storyboardIdentifier":"ActiveTaskSteps"
+                              },
+                              "actions":{
+                                  "skip":{
+                                      "type":"navigation",
+                                      "skipToIdentifier":"countdown.1",
+                                      "buttonTitle": "Restart test"
+                                  },
+                                  "learnMore":{
+                                      "type":"navigation",
+                                      "skipToIdentifier": "walkInstructions",
+                                      "buttonTitle": "Review instructions"
+                                  }
                               },
                               "commands":["transitionAutomatically", "shouldDisableIdleTimer", "vibrate", "playSound"],
                               "spokenInstructions":{
@@ -283,7 +289,7 @@
                  }
              },
              {
-                 "identifier":"countdown",
+                 "identifier":"countdown.2",
                  "type":"countdown",
                  "text":"Begin in...",
                  "isFirstRunOnly": true,
@@ -311,7 +317,6 @@
                                  {
                                  "identifier":"motion",
                                  "type":"motion",
-                                 "startStepIdentifier":"countdown",
                                  "requiresBackgroundAudio":true,
                                  "recorderTypes":[
                                                   "accelerometer",
@@ -336,6 +341,18 @@
                               "viewTheme":{
                                   "viewIdentifier":"Action",
                                   "storyboardIdentifier":"ActiveTaskSteps"
+                              },
+                              "actions":{
+                                  "skip":{
+                                      "type":"navigation",
+                                      "skipToIdentifier":"countdown.1",
+                                      "buttonTitle": "Restart test"
+                                  },
+                                  "learnMore":{
+                                      "type":"navigation",
+                                      "skipToIdentifier": "walkInstructions",
+                                      "buttonTitle": "Review instructions"
+                                  }
                               },
                               "spokenInstructions":{
                                   "start":"Turn around 360 degrees, then stand still, with your feet about shoulder-width apart. Rest your arms at your side and try to not move.",

--- a/mPower2/MotorControl/StepObjects/MCTInstructionStepObject.swift
+++ b/mPower2/MotorControl/StepObjects/MCTInstructionStepObject.swift
@@ -48,7 +48,7 @@ open class MCTInstructionStepObject : RSDActiveUIStepObject, RSDNavigationSkipRu
         // if self.isFirstRunOnly == nil the JSON file probably left out this field so we
         // assume that this step will always be shown
         guard (self.isFirstRunOnly ?? false),
-              let isFirstRunResult = result?.findResult(with: MCTOverviewStepViewController.firstRunKey) as? RSDAnswerResult,
+              let isFirstRunResult = result?.asyncResults?.first(where: { $0.identifier == MCTOverviewStepViewController.firstRunKey}) as? RSDAnswerResult,
               let isFirstRun = isFirstRunResult.value as? Bool
             else {
             return false

--- a/mPower2/MotorControl/ViewControllers/MCTActiveStepViewController.swift
+++ b/mPower2/MotorControl/ViewControllers/MCTActiveStepViewController.swift
@@ -33,6 +33,9 @@
 
 import Foundation
 
+extension RSDActiveStepViewController : MCTInternalStepController {
+}
+
 open class MCTActiveStepViewController : RSDActiveStepViewController, MCTHandStepController {
     
     /// Retuns the imageView, in this case the image from the navigationHeader.
@@ -86,16 +89,11 @@ open class MCTActiveStepViewController : RSDActiveStepViewController, MCTHandSte
         self.unitLabel?.text = Localization.localizedString(localizationKey)
     }
     
-    @IBAction func restartButtonTapped(_ sender: Any) {
-        skipForward()
-    }
-    
-    /// Override skip forward to skip backward to the walk step.
-    override open func skipForward() {
-        // TODO: rkolmos 04/05/2018 refactor Research to support linking an RSDUIAction to navigation
-        guard let activeStep = self.step as? RSDActiveUIStepObject else { return }
-        activeStep.nextStepIdentifier = "walk"
-        super.skipForward()
+    /// Override show learn more to insert the first run answer result.
+    override open func showLearnMore() {
+        // Update the first run to show the full instructions.
+        setIsFirstRunResult(true)
+        super.showLearnMore()
     }
     
     /// Override to return the instruction with the formatted text replaced.

--- a/mPower2/MotorControl/ViewControllers/MCTCountdownStepViewController.swift
+++ b/mPower2/MotorControl/ViewControllers/MCTCountdownStepViewController.swift
@@ -1,0 +1,48 @@
+//
+//  MCTCountdownStepViewController.swift
+//  MotorControl
+//
+//  Copyright © 2018 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import Foundation
+
+extension MCTCountdownStepViewController : MCTInternalStepController {
+}
+
+open class MCTCountdownStepViewController : RSDCountdownStepViewController {
+    
+    
+    /// Override show learn more to insert the first run answer result.
+    override open func showLearnMore() {
+        // Update the first run to show the full instructions.
+        setIsFirstRunResult(true)
+        super.showLearnMore()
+    }
+}

--- a/mPower2/MotorControl/ViewControllers/MCTOverviewStepViewController.swift
+++ b/mPower2/MotorControl/ViewControllers/MCTOverviewStepViewController.swift
@@ -33,6 +33,24 @@
 
 import Foundation
 
+internal protocol MCTInternalStepController : RSDStepController {
+}
+
+extension MCTInternalStepController {
+    
+    /// Adds a result for whether or not this run represents a "first run", A "first run"
+    /// occurs anytime the user has never run the task before, or hasn't run the task in
+    /// one month.
+    internal func setIsFirstRunResult(_ isFirstRun: Bool) {
+        var firstRunResult = RSDAnswerResultObject(identifier: MCTOverviewStepViewController.firstRunKey, answerType: .boolean)
+        firstRunResult.value = isFirstRun
+        self.taskController.taskPath.topLevelTaskPath.appendAsyncResult(with: firstRunResult)
+    }
+}
+
+extension MCTOverviewStepViewController : MCTInternalStepController {
+}
+
 open class MCTOverviewStepViewController : RSDOverviewStepViewController {
     
     /// The key to store whether or not this is a first run in the task result under.
@@ -91,7 +109,7 @@ open class MCTOverviewStepViewController : RSDOverviewStepViewController {
         let lastRun = defaults.object(forKey: timestampKey) as? Date
         let monthAgo = Calendar.current.date(byAdding: .month, value: -1, to: Date())!
         let isFirstRun = (lastRun == nil) || (lastRun! < monthAgo)
-        _setIsFirstRunResult(isFirstRun)
+        setIsFirstRunResult(isFirstRun)
         defaults.set(Date(), forKey: timestampKey)
         /// The image view that is used to show the animation.
         var animationView: UIImageView? {
@@ -123,14 +141,7 @@ open class MCTOverviewStepViewController : RSDOverviewStepViewController {
         self.scrollViewBackgroundHeightConstraint.constant = placementType == .topMarginBackground ? self.statusBarBackgroundView!.bounds.height : CGFloat(0)
     }
     
-    /// Adds a result for whether or not this run represents a "first run", A "first run"
-    /// occurs anytime the user has never run the task before, or hasn't run the task in
-    /// one month.
-    private func _setIsFirstRunResult(_ isFirstRun: Bool) {
-        var stepResult = RSDAnswerResultObject(identifier: MCTOverviewStepViewController.firstRunKey, answerType: .boolean)
-        stepResult.value = isFirstRun
-        self.taskController.taskPath.appendStepHistory(with: stepResult)
-    }
+
     
     /// Sets whether the components are hidden, and whether scrolling is enabled
     /// based on whether this view should be showing the full task info or the

--- a/mPower2/MotorControl/ViewControllers/MCTOverviewStepViewController.swift
+++ b/mPower2/MotorControl/ViewControllers/MCTOverviewStepViewController.swift
@@ -38,7 +38,7 @@ internal protocol MCTInternalStepController : RSDStepController {
 
 extension MCTInternalStepController {
     
-    /// Adds a result for whether or not this run represents a "first run", A "first run"
+    /// Adds a result for whether or not this run represents a "first run". A "first run"
     /// occurs anytime the user has never run the task before, or hasn't run the task in
     /// one month.
     internal func setIsFirstRunResult(_ isFirstRun: Bool) {

--- a/mPower2/MotorControlTests/NavigationTests.swift
+++ b/mPower2/MotorControlTests/NavigationTests.swift
@@ -90,7 +90,7 @@ class NavigationTests: XCTestCase {
     private func _insertIsFirstRunResult(for taskController: TestTaskController, isFirstRun: Bool) {
         var answerResult = RSDAnswerResultObject(identifier: "isFirstRun", answerType: .boolean)
         answerResult.value = isFirstRun
-        self.taskController.taskPath.appendStepHistory(with: answerResult)
+        self.taskController.taskPath.topLevelTaskPath.appendAsyncResult(with: answerResult)
     }
     
     private func _setupInstructionStepTest() {

--- a/mPower2/mPower2.xcodeproj/project.pbxproj
+++ b/mPower2/mPower2.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		F80CB9FD207D3AD800B4EE5D /* MotorControl.strings in Resources */ = {isa = PBXBuildFile; fileRef = F80CB9FC207D3AD800B4EE5D /* MotorControl.strings */; };
 		F8188FB62072F430009AC215 /* Triggers.json in Resources */ = {isa = PBXBuildFile; fileRef = F8188FB52072F430009AC215 /* Triggers.json */; };
 		F82AE7B62063160B00952D74 /* UIColor+mPowerTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = F82AE7B52063160B00952D74 /* UIColor+mPowerTheme.swift */; };
+		F8460D752097CF0C0084E197 /* MCTCountdownStepViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8460D742097CF0C0084E197 /* MCTCountdownStepViewController.swift */; };
 		F854590E208F986D00D37243 /* NSLocale+UnitTest.h in Headers */ = {isa = PBXBuildFile; fileRef = F854590D208F986D00D37243 /* NSLocale+UnitTest.h */; };
 		F8545977208FA2ED00D37243 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8545976208FA2ED00D37243 /* AppDelegate.swift */; };
 		F8545979208FA2ED00D37243 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8545978208FA2ED00D37243 /* ViewController.swift */; };
@@ -342,6 +343,7 @@
 		F80CB9FC207D3AD800B4EE5D /* MotorControl.strings */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; path = MotorControl.strings; sourceTree = "<group>"; };
 		F8188FB52072F430009AC215 /* Triggers.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Triggers.json; sourceTree = "<group>"; };
 		F82AE7B52063160B00952D74 /* UIColor+mPowerTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+mPowerTheme.swift"; sourceTree = "<group>"; };
+		F8460D742097CF0C0084E197 /* MCTCountdownStepViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCTCountdownStepViewController.swift; sourceTree = "<group>"; };
 		F854590D208F986D00D37243 /* NSLocale+UnitTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSLocale+UnitTest.h"; sourceTree = "<group>"; };
 		F8545974208FA2ED00D37243 /* mPower2TestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = mPower2TestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8545976208FA2ED00D37243 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -458,6 +460,7 @@
 			children = (
 				B59FC272206EA445002BFDB9 /* MCTActiveStepViewController.swift */,
 				B532AD03208158860009EAD3 /* MCTCompletionStepViewController.swift */,
+				F8460D742097CF0C0084E197 /* MCTCountdownStepViewController.swift */,
 				B5D822F6207449D400C03F3C /* MCTInstructionStepViewController.swift */,
 				B59FC28B20728BC7002BFDB9 /* MCTOverviewStepViewController.swift */,
 				B532AD0520817F610009EAD3 /* MCTTappingCompletionStepViewController.swift */,
@@ -1095,6 +1098,7 @@
 				B56E4D0A207BCA110009C489 /* MCTInstructionStepObject.swift in Sources */,
 				B5386FC1206B0211005A0FAC /* MCTFactory.swift in Sources */,
 				F80CB9EF207D2DE400B4EE5D /* MCTTappingResultObject.swift in Sources */,
+				F8460D752097CF0C0084E197 /* MCTCountdownStepViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Fix the “Restart Test” and “Review Instructions” buttons so that they will work for both Walk and Balance **and** Tremor. This fixes a bug where tapping on “Restart Test” in the tremor activity will reset the actions. This also allows the countdown to include a review instructions button and allows the buttons to be easily hidden if no action is associated with them.