### PR TITLE
Update triggers & symptoms to look at previous runs.

### DIFF
--- a/mPower2/mPower2.xcodeproj/project.pbxproj
+++ b/mPower2/mPower2.xcodeproj/project.pbxproj
@@ -88,6 +88,7 @@
 		F88E8E0620ADEE4700117A99 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F8D3E77D2062F1B900CD351C /* Main.storyboard */; };
 		F88E8E0920ADEE6000117A99 /* mPower2.strings in Resources */ = {isa = PBXBuildFile; fileRef = 03C9DD0B20A4F956007074EE /* mPower2.strings */; };
 		F88E8E0A20ADEE6C00117A99 /* BridgeInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = F8D3E7F62063039200CD351C /* BridgeInfo.plist */; };
+		F89B3DA920C60F8B002EAE2D /* TodayScheduleManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F89B3DA820C60F8B002EAE2D /* TodayScheduleManagerTests.swift */; };
 		F8C58DB120AF4823001C7B7F /* TodayScheduleManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8C58DB020AF4823001C7B7F /* TodayScheduleManager.swift */; };
 		F8C58DB220AF4823001C7B7F /* TodayScheduleManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8C58DB020AF4823001C7B7F /* TodayScheduleManager.swift */; };
 		F8C58DCA20AF5E86001C7B7F /* StudyBurstScheduleManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8C58DC920AF5E86001C7B7F /* StudyBurstScheduleManager.swift */; };
@@ -416,6 +417,7 @@
 		F88419B4207EC14400028A2B /* ResourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceTests.swift; sourceTree = "<group>"; };
 		F88419CC207EC22A00028A2B /* MotorControlTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MotorControlTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		F88419CE207EC22B00028A2B /* NSLocale+UnitTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSLocale+UnitTest.m"; sourceTree = "<group>"; };
+		F89B3DA820C60F8B002EAE2D /* TodayScheduleManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayScheduleManagerTests.swift; sourceTree = "<group>"; };
 		F8C58DB020AF4823001C7B7F /* TodayScheduleManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayScheduleManager.swift; sourceTree = "<group>"; };
 		F8C58DC920AF5E86001C7B7F /* StudyBurstScheduleManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyBurstScheduleManager.swift; sourceTree = "<group>"; };
 		F8C58DD420AF8CCC001C7B7F /* SurveyScheduleManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyScheduleManager.swift; sourceTree = "<group>"; };
@@ -683,6 +685,7 @@
 			children = (
 				F8D3E7902062F1B900CD351C /* Info.plist */,
 				F854599F208FA58800D37243 /* ResourceTests.swift */,
+				F89B3DA820C60F8B002EAE2D /* TodayScheduleManagerTests.swift */,
 			);
 			path = mPower2Tests;
 			sourceTree = "<group>";
@@ -1225,6 +1228,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F89B3DA920C60F8B002EAE2D /* TodayScheduleManagerTests.swift in Sources */,
 				F85459A0208FA58800D37243 /* ResourceTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/mPower2/mPower2/View Controllers/TaskBrowserViewController.swift
+++ b/mPower2/mPower2/View Controllers/TaskBrowserViewController.swift
@@ -119,7 +119,7 @@ class TaskBrowserViewController: UIViewController, RSDTaskViewControllerDelegate
     }
     
     func startTask(for taskInfo: RSDTaskInfo) {
-        let (taskPath, _, _) = selectedScheduleManager.instantiateTaskPath(for: taskInfo)
+        let (taskPath, _) = selectedScheduleManager.instantiateTaskPath(for: taskInfo)
         let vc = RSDTaskViewController(taskPath: taskPath)
         vc.delegate = self
         self.present(vc, animated: true, completion: nil)

--- a/mPower2/mPower2Tests/TodayScheduleManagerTests.swift
+++ b/mPower2/mPower2Tests/TodayScheduleManagerTests.swift
@@ -1,0 +1,127 @@
+//
+//  TodayScheduleManagerTests.swift
+//  mPower2Tests
+//
+//  Copyright © 2018 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import XCTest
+@testable import mPower2TestApp
+import Research
+import BridgeApp
+
+class TodayScheduleManagerTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    func testTodaySchedule_TriggerCount() {
+        
+        let activityManager = ActivityManager()
+        let startOfDay = Date().startOfDay()
+
+        let run1 = startOfDay.addingTimeInterval(2 * 60 * 60)
+        let run1Timestamp = (run1 as NSDate).iso8601String()!
+        
+        let run2 = startOfDay.addingTimeInterval(4 * 60 * 60)
+        let run2Timestamp = (run2 as NSDate).iso8601String()!
+        
+        let clientData1: NSDictionary =
+            [
+                "items" : [
+                    [
+                        "identifier" : "itemA",
+                        "loggedDate" : run1Timestamp,
+                    ],
+                    [
+                        "identifier" : "itemB"
+                    ]
+                ],
+                "endDate" : run1Timestamp,
+                "startDate" : run1Timestamp,
+                "type" : "loggingCollection",
+                "identifier" : "logging"
+            ]
+        
+        let clientData2: NSDictionary =
+            [
+                "items" : [
+                    [
+                        "identifier" : "itemA",
+                        "loggedDate" : run2Timestamp
+                        ],
+                    [
+                        "identifier" : "itemB",
+                        "loggedDate" : run2Timestamp
+                    ]
+                ],
+                "endDate" : run2Timestamp,
+                "startDate" : run2Timestamp,
+                "type" : "loggingCollection",
+                "identifier" : "logging"
+            ]
+        
+        let schedule1 = activityManager.createSchedule(with: .triggersTask,
+                                           scheduledOn: startOfDay,
+                                           expiresOn: nil,
+                                           finishedOn: run1,
+                                           clientData: [clientData1] as NSArray,
+                                           schedulePlanGuid: nil)
+        let schedule2 = activityManager.createSchedule(with: .triggersTask,
+                                                       scheduledOn: run1.addingTimeInterval(60),
+                                                       expiresOn: nil,
+                                                       finishedOn: run2,
+                                                       clientData: [clientData2] as NSArray,
+                                                       schedulePlanGuid: nil)
+        
+        let scheduleManager = TodayHistoryScheduleManager()
+        let scheduledActivities = [schedule1, schedule2]
+        
+        let items = scheduleManager.consolidateItems(scheduledActivities)
+        
+        XCTAssertEqual(items.count, 1)
+        
+        guard let triggersItem = items.first else {
+            XCTFail("Failed to create triggers item.")
+            return
+        }
+        
+        XCTAssertEqual(triggersItem.count, 3)
+        XCTAssertEqual(triggersItem.type, .triggers)
+    }
+}
+
+


### PR DESCRIPTION
Triggers and symptoms should look at the most recent schedule and the most recent client data on that schedule for determining what to display next run. But the today counter needs to look at the number of logged items.