### PR TITLE
More incremental tweaks to the study burst logic

### DIFF
--- a/mPower2/mPower2/mPower2.strings
+++ b/mPower2/mPower2/mPower2.strings
@@ -46,7 +46,6 @@
 // Titles for the activity groups and infos.
 "Measuring" = "Measuring";
 "Tracking" = "Tracking";
-"Study Burst" = "Study Burst";
 "Triggers" = "Trigger";
 "Symptoms" = "Symptom";
 "Medication" = "Medication";
@@ -69,6 +68,7 @@
 "%@_ESTIMATED_MINUTES" = "%@ minutes";
 
 // Study Burst titles
+"STUDY_BURST_ACTION_BAR_TITLE" = "Study Burst";
 "STUDY_BURST_TITLE_DAY_1" = "This is your time!";
 "STUDY_BURST_TITLE_DAY_2" = "You are making a difference!";
 "STUDY_BURST_TITLE_DAY_3" = "Great Job!";

--- a/mPower2/mPower2TestApp/ActivityManager.swift
+++ b/mPower2/mPower2TestApp/ActivityManager.swift
@@ -37,26 +37,48 @@ import BridgeApp
 import Research
 
 public struct StudySetup {
-    init() { }
+    
+    init(studyBurstDay: UInt = 3,
+         studyBurstFinishedOnDays: [Int] = [0, 2],
+         studyBurstSurveyFinishedOnDays: [RSDIdentifier : Int] = [:],
+         finishedTodayTasks: [RSDIdentifier] = [.tappingTask, .walkAndBalanceTask],
+         timeUntilExpires: TimeInterval = 15 * 60,
+         dataGroups: [String] = []) {
+        
+        self.studyBurstDay = studyBurstDay
+        self.studyBurstFinishedOnDays = studyBurstFinishedOnDays.filter { $0 < studyBurstDay }
+        self.studyBurstSurveyFinishedOnDays = studyBurstSurveyFinishedOnDays.filter { $0.value <= studyBurstDay }
+        self.finishedTodayTasks = finishedTodayTasks
+        self.timeUntilExpires = timeUntilExpires
+        self.dataGroups = dataGroups
+    }
     
     /// First name of the participant.
     var firstName = "Rumplestiltskin"
+
+    /// Study Burst "day" where Day 0 is the day the participant was "created".
+    let studyBurstDay: UInt
+    
+    /// The days in the past when the particpant finished all the tasks.
+    var studyBurstFinishedOnDays: [Int]
+    
+    /// The days when the study burst was finished.
+    var studyBurstSurveyFinishedOnDays: [RSDIdentifier : Int]
+    
+    /// A list of the tasks to mark as finished today for a study burst. If included, this will be used to
+    /// define the order of the tasks for display in the study burst view.
+    var finishedTodayTasks: [RSDIdentifier]
+    
+    /// The time to use as the time until today's finished tasks will expire. Default = 15 min.
+    var timeUntilExpires: TimeInterval
     
     /// The data groups to set for this participant.
-    var dataGroups: [String] = []
+    var dataGroups: [String]
     
     /// The date when the participant started the study. Hardcoded to 6:15AM local time.
     var createdOn: Date {
         return Date().startOfDay().addingNumberOfDays(-1 * Int(studyBurstDay)).addingTimeInterval(6.25 * 60 * 60)
     }
-
-    /// Study Burst "day" where Day 0 is the day the participant was "created".
-    var studyBurstDay: UInt = 3
-    
-    /// The days in the past when the particpant finished all the tasks.
-    var studyBurstFinishedOnDays: [Int] = [0, 2]
-    
-    var studyBurstSurveyFinishedOnDays: [RSDIdentifier : Int] = [:]
     
     /// Generated days of the study burst to mark as finished. This only applies to days that are past.
     func mapStudyBurstFinishedOn() -> [Int : Date] {
@@ -80,13 +102,6 @@ public struct StudySetup {
         }
     }
     
-    /// A list of the tasks to mark as finished today for a study burst. If included, this will be used to
-    /// define the order of the tasks for display in the study burst view.
-    var finishedTodayTasks: [RSDIdentifier] = [.tappingTask, .walkAndBalanceTask]
-    
-    /// The time to use as the time until today's finished tasks will expire. Default = 15 min.
-    var timeUntilExpires: TimeInterval = 15 * 60
-    
     func createParticipant() -> SBBStudyParticipant {
         return SBBStudyParticipant(dictionaryRepresentation: [
             "createdOn" : (createdOn as NSDate).iso8601String(),
@@ -97,10 +112,82 @@ public struct StudySetup {
     }
 }
 
+extension StudySetup {
+    
+    static func finishedOnDays(_ studyBurstDay: Int, _ missingCount: Int) -> [Int] {
+        if studyBurstDay == missingCount {
+            return []
+        }
+        var finishedDays: [Int] = Array(0..<studyBurstDay)
+        if missingCount > 0 {
+            let offset = finishedDays.count / (missingCount + 1)
+            for ii in 0..<missingCount {
+                finishedDays.remove(at: offset * (ii + 1))
+            }
+        }
+        return finishedDays
+    }
+    
+    static func previousFinishedSurveys(for studyBurstDay: Int) -> [RSDIdentifier : Int] {
+        var surveyMap = [RSDIdentifier : Int]()
+        if studyBurstDay > 0 {
+            surveyMap[.demographics] = 0
+            surveyMap[.studyBurstReminder] = 0
+            surveyMap[.medicationTask] = 0
+        }
+        if studyBurstDay > 13 {
+            surveyMap[.engagement] = 13
+        }
+        return surveyMap
+    }
+    
+    static let day1_tasksFinished_demographicsNotFinished =
+        StudySetup(studyBurstDay: 0,
+                   studyBurstFinishedOnDays: [],
+                   studyBurstSurveyFinishedOnDays: [:],
+                   finishedTodayTasks: RSDIdentifier.measuringTasks)
+    
+    static let day2_demographicsNotFinished =
+        StudySetup(studyBurstDay: 1,
+                   studyBurstFinishedOnDays: [0],
+                   studyBurstSurveyFinishedOnDays: [:],
+                   finishedTodayTasks: [])
+    
+    static let day14_missing1_tasksFinished_engagementNotFinished =
+        StudySetup(studyBurstDay: 13,
+                   studyBurstFinishedOnDays: finishedOnDays(13, 1),
+                   studyBurstSurveyFinishedOnDays: previousFinishedSurveys(for: 12),
+                   finishedTodayTasks: RSDIdentifier.measuringTasks)
+    
+    static let day15_missing1_tasksFinished_engagementNotFinished =
+        StudySetup(studyBurstDay: 14,
+                   studyBurstFinishedOnDays: finishedOnDays(14, 1),
+                   studyBurstSurveyFinishedOnDays: previousFinishedSurveys(for: 12),
+                   finishedTodayTasks: RSDIdentifier.measuringTasks)
+    
+    static let day15_missing2_tasksFinished_engagementNotFinished =
+        StudySetup(studyBurstDay: 14,
+                   studyBurstFinishedOnDays: finishedOnDays(14, 2),
+                   studyBurstSurveyFinishedOnDays: previousFinishedSurveys(for: 12),
+                   finishedTodayTasks: RSDIdentifier.measuringTasks)
+    
+    static let day15_burstCompleted_engagementNotFinished =
+        StudySetup(studyBurstDay: 14,
+                   studyBurstFinishedOnDays: finishedOnDays(14, 0),
+                   studyBurstSurveyFinishedOnDays: previousFinishedSurveys(for: 12),
+                   finishedTodayTasks: [])
+    
+    static let day15_burstCompleted_engagementFinished =
+        StudySetup(studyBurstDay: 14,
+                   studyBurstFinishedOnDays: finishedOnDays(14, 0),
+                   studyBurstSurveyFinishedOnDays: previousFinishedSurveys(for: 14),
+                   finishedTodayTasks: [])
+}
+
 public struct SurveyReference : Codable {
     
     let guid: String
-    let identifier: String
+    let identifier: RSDIdentifier
     let createdOn: String
     
     static var all: [SurveyReference] = {
@@ -198,21 +285,17 @@ public class ActivityManager : NSObject, SBBActivityManagerProtocol {
                                                    schedulePlanGuid: "3d898a6f-1ef2-4ece-9e9f-025d94bcd130",
                                                    activityGuidMap: nil)
     
-        // measuring tasks are persistent.
+        // set default for the sort order
         let finishedTodayTasks = studySetup.finishedTodayTasks
-        var orderedTasks = finishedTodayTasks
-        activityGroup.activityIdentifiers.forEach {
-            if !orderedTasks.contains($0) {
-                orderedTasks.append($0)
-            }
-        }
-        
-        UserDefaults.standard.set(orderedTasks.map { $0.stringValue }, forKey: "StudyBurstTaskOrder")
-        UserDefaults.standard.set(Date(), forKey: "StudyBurstTimestamp")
+        var sortOrder = finishedTodayTasks
+        var unfinished = activityGroup.activityIdentifiers.filter { !finishedTodayTasks.contains($0) }
+        unfinished.shuffle()
+        sortOrder.append(contentsOf: unfinished)
+        StudyBurstScheduleManager.setOrderedTasks(sortOrder.map { $0.stringValue })
         
         let studyBurstFinishedOn = studySetup.mapStudyBurstFinishedOn()
         let studyBurstDates = studyBurstFinishedOn.enumerated().map { $0.element.value }.sorted()
-        orderedTasks.enumerated().forEach{ (offset, identifier) in
+        sortOrder.enumerated().forEach{ (offset, identifier) in
             
             let finishedTime: TimeInterval = studySetup.timeUntilExpires - 3600 + TimeInterval(offset) * 4 * 60
             var datesToAdd = studyBurstDates
@@ -264,10 +347,10 @@ public class ActivityManager : NSObject, SBBActivityManagerProtocol {
         
         // Add all the surveys that are suppose to be from the server.
         SurveyReference.all.forEach {
-            let survey = createSchedule(with: RSDIdentifier(rawValue: $0.identifier),
+            let survey = createSchedule(with: $0.identifier,
                                               scheduledOn: studySetup.createdOn,
                                               expiresOn: nil,
-                                              finishedOn: surveyMap[.demographics],
+                                              finishedOn: surveyMap[$0.identifier],
                                               clientData: nil,
                                               schedulePlanGuid: nil,
                                               survey: $0)

--- a/mPower2/mPower2TestApp/AppDelegate.swift
+++ b/mPower2/mPower2TestApp/AppDelegate.swift
@@ -55,6 +55,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         testHarness = SBBBridgeTestHarness(studyIdentifier: "sage-mpower-2-test")
         
         let activityManager = ActivityManager()
+        
+        // NOTE: syoung 06/28/2018 You can set different study setup objects to test different states.
+        // activityManager.studySetup = .day1_tasksFinished_demographicsNotFinished
+        
         SBBComponentManager.registerComponent(activityManager, for: SBBActivityManager.self)
         activityManager.buildSchedules()
         

--- a/mPower2/mPower2TestApp/AppDelegate.swift
+++ b/mPower2/mPower2TestApp/AppDelegate.swift
@@ -62,7 +62,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         SBBComponentManager.registerComponent(participantManager, for: SBBParticipantManager.self)
         
         SurveyReference.all.forEach {
-            testHarness!.setJSONWithFile($0.identifier,
+            testHarness!.setJSONWithFile($0.identifier.stringValue,
                                          forEndpoint: $0.endpoint,
                                          andMethod: "GET")
         }

--- a/mPower2/mPower2Tests/StudyBurstTests.swift
+++ b/mPower2/mPower2Tests/StudyBurstTests.swift
@@ -85,13 +85,7 @@ class StudyBurstTests: XCTestCase {
     
     func testStudyBurstComplete_DayOne() {
         
-        let scheduleManager = TestStudyBurstScheduleManager()
-        var studySetup = StudySetup()
-        studySetup.studyBurstDay = 0
-        studySetup.studyBurstFinishedOnDays = []
-        studySetup.finishedTodayTasks = scheduleManager.activityGroup?.activityIdentifiers ?? []
-        scheduleManager._activityManager.studySetup = studySetup
-        scheduleManager._activityManager.buildSchedules()
+        let scheduleManager = TestStudyBurstScheduleManager(.day1_tasksFinished_demographicsNotFinished)
         
         let expect = expectation(description: "Update finished called.")
         scheduleManager.updateFinishedBlock = {
@@ -127,15 +121,7 @@ class StudyBurstTests: XCTestCase {
     
     func testStudyBurstComplete_Day15_MissingOne() {
         
-        let scheduleManager = TestStudyBurstScheduleManager()
-        var studySetup = StudySetup()
-        studySetup.studyBurstDay = 14
-        var finishedDays: [Int] = Array(0...13)
-        finishedDays.remove(at: 2)
-        studySetup.studyBurstFinishedOnDays = finishedDays
-        studySetup.finishedTodayTasks = scheduleManager.activityGroup?.activityIdentifiers ?? []
-        scheduleManager._activityManager.studySetup = studySetup
-        scheduleManager._activityManager.buildSchedules()
+        let scheduleManager = TestStudyBurstScheduleManager(.day15_missing1_tasksFinished_engagementNotFinished)
         
         let expect = expectation(description: "Update finished called.")
         scheduleManager.updateFinishedBlock = {
@@ -161,17 +147,7 @@ class StudyBurstTests: XCTestCase {
     
     func testStudyBurstComplete_Day15_MissingTwo() {
         
-        let scheduleManager = TestStudyBurstScheduleManager()
-        var studySetup = StudySetup()
-        studySetup.studyBurstDay = 14
-        var finishedDays: [Int] = Array(0...13)
-        finishedDays.remove(at: 2)
-        finishedDays.remove(at: 4)
-        studySetup.studyBurstFinishedOnDays = finishedDays
-        studySetup.studyBurstSurveyFinishedOnDays = [.demographics : 0, .studyBurstReminder : 0]
-        studySetup.finishedTodayTasks = scheduleManager.activityGroup?.activityIdentifiers ?? []
-        scheduleManager._activityManager.studySetup = studySetup
-        scheduleManager._activityManager.buildSchedules()
+        let scheduleManager = TestStudyBurstScheduleManager(.day15_missing2_tasksFinished_engagementNotFinished)
         
         let expect = expectation(description: "Update finished called.")
         scheduleManager.updateFinishedBlock = {
@@ -197,16 +173,7 @@ class StudyBurstTests: XCTestCase {
     
     func testStudyBurstComplete_Day14_MissingOne() {
         
-        let scheduleManager = TestStudyBurstScheduleManager()
-        var studySetup = StudySetup()
-        studySetup.studyBurstDay = 13
-        var finishedDays: [Int] = Array(0...13)
-        finishedDays.remove(at: 2)
-        studySetup.studyBurstFinishedOnDays = finishedDays
-        studySetup.studyBurstSurveyFinishedOnDays = [.demographics : 0, .studyBurstReminder : 0]
-        studySetup.finishedTodayTasks = scheduleManager.activityGroup?.activityIdentifiers ?? []
-        scheduleManager._activityManager.studySetup = studySetup
-        scheduleManager._activityManager.buildSchedules()
+        let scheduleManager = TestStudyBurstScheduleManager(.day14_missing1_tasksFinished_engagementNotFinished)
         
         let expect = expectation(description: "Update finished called.")
         scheduleManager.updateFinishedBlock = {
@@ -232,14 +199,7 @@ class StudyBurstTests: XCTestCase {
     
     func testStudyBurstComplete_Day2_NoDemographics() {
         
-        let scheduleManager = TestStudyBurstScheduleManager()
-        var studySetup = StudySetup()
-        studySetup.studyBurstDay = 1
-        let finishedDays: [Int] = Array(0...1)
-        studySetup.studyBurstFinishedOnDays = finishedDays
-        studySetup.finishedTodayTasks = scheduleManager.activityGroup?.activityIdentifiers ?? []
-        scheduleManager._activityManager.studySetup = studySetup
-        scheduleManager._activityManager.buildSchedules()
+        let scheduleManager = TestStudyBurstScheduleManager(.day2_demographicsNotFinished)
         
         let expect = expectation(description: "Update finished called.")
         scheduleManager.updateFinishedBlock = {
@@ -255,8 +215,8 @@ class StudyBurstTests: XCTestCase {
         XCTAssertNotNil(scheduleManager.activityGroup)
         XCTAssertEqual(scheduleManager.dayCount, 2)
         XCTAssertTrue(scheduleManager.hasStudyBurst)
-        XCTAssertEqual(scheduleManager.finishedSchedules.count, 3)
-        XCTAssertTrue(scheduleManager.isCompletedForToday)
+        XCTAssertEqual(scheduleManager.finishedSchedules.count, 0)
+        XCTAssertFalse(scheduleManager.isCompletedForToday)
         XCTAssertFalse(scheduleManager.isLastDay)
         
         let completionTask = scheduleManager.completionTaskPath()
@@ -265,14 +225,7 @@ class StudyBurstTests: XCTestCase {
     
     func testStudyBurstComplete_Day15_BurstComplete_EngagementNotComplete() {
         
-        let scheduleManager = TestStudyBurstScheduleManager()
-        var studySetup = StudySetup()
-        studySetup.studyBurstDay = 14
-        let finishedDays: [Int] = Array(0...13)
-        studySetup.studyBurstFinishedOnDays = finishedDays
-        studySetup.finishedTodayTasks = scheduleManager.activityGroup?.activityIdentifiers ?? []
-        scheduleManager._activityManager.studySetup = studySetup
-        scheduleManager._activityManager.buildSchedules()
+        let scheduleManager = TestStudyBurstScheduleManager(.day15_burstCompleted_engagementNotFinished)
         
         let expect = expectation(description: "Update finished called.")
         scheduleManager.updateFinishedBlock = {
@@ -297,14 +250,7 @@ class StudyBurstTests: XCTestCase {
     
     func testStudyBurstComplete_Day15_BurstComplete_EngagementComplete() {
         
-        let scheduleManager = TestStudyBurstScheduleManager()
-        var studySetup = StudySetup()
-        studySetup.studyBurstDay = 14
-        let finishedDays: [Int] = Array(0...13)
-        studySetup.studyBurstFinishedOnDays = finishedDays
-        studySetup.finishedTodayTasks = scheduleManager.activityGroup?.activityIdentifiers ?? []
-        scheduleManager._activityManager.studySetup = studySetup
-        scheduleManager._activityManager.buildSchedules()
+        let scheduleManager = TestStudyBurstScheduleManager(.day15_burstCompleted_engagementFinished)
         
         let expect = expectation(description: "Update finished called.")
         scheduleManager.updateFinishedBlock = {
@@ -324,13 +270,19 @@ class StudyBurstTests: XCTestCase {
         XCTAssertFalse(scheduleManager.isLastDay)
         
         let completionTask = scheduleManager.completionTaskPath()
-        XCTAssertNotNil(completionTask)
+        XCTAssertNil(completionTask)
     }
 }
 
 class TestStudyBurstScheduleManager : StudyBurstScheduleManager {
     
-    var _activityManager = ActivityManager()
+    init(_ studySetup: StudySetup) {
+        super.init()
+        self._activityManager.studySetup = studySetup
+        self._activityManager.buildSchedules()
+    }
+    
+    let _activityManager = ActivityManager()
     
     override var activityManager: SBBActivityManagerProtocol {
         return _activityManager

--- a/mPower2/mPower2Tests/StudyBurstTests.swift
+++ b/mPower2/mPower2Tests/StudyBurstTests.swift
@@ -83,7 +83,7 @@ class StudyBurstTests: XCTestCase {
         }
     }
     
-    func testStudyBurstComplete_DayOne() {
+    func testStudyBurstComplete_Day1() {
         
         let scheduleManager = TestStudyBurstScheduleManager(.day1_tasksFinished_demographicsNotFinished)
         
@@ -104,6 +104,9 @@ class StudyBurstTests: XCTestCase {
         XCTAssertEqual(scheduleManager.finishedSchedules.count, 3)
         XCTAssertTrue(scheduleManager.isCompletedForToday)
         XCTAssertFalse(scheduleManager.isLastDay)
+        XCTAssertEqual(scheduleManager.calculateThisDay(), 1)
+        XCTAssertEqual(scheduleManager.pastSurveySchedules.count, 0)
+        XCTAssertNotNil(scheduleManager.todayCompletionTask)
         
         let demographics = scheduleManager.scheduledActivities.filter {
             $0.activityIdentifier == RSDIdentifier.demographics.stringValue
@@ -117,6 +120,91 @@ class StudyBurstTests: XCTestCase {
         
         let completionTask = scheduleManager.completionTaskPath()
         XCTAssertNotNil(completionTask)
+        
+        XCTAssertNotNil(scheduleManager.actionBarItem)
+        XCTAssertEqual(scheduleManager.actionBarItem?.title, "Health Survey")
+        XCTAssertEqual(scheduleManager.actionBarItem?.detail, "4 Minutes")
+    }
+    
+    func testStudyBurstComplete_Day1_SurveysFinished() {
+        
+        let scheduleManager = TestStudyBurstScheduleManager(.day1_tasksFinished_surveysFinished)
+        
+        let expect = expectation(description: "Update finished called.")
+        scheduleManager.updateFinishedBlock = {
+            expect.fulfill()
+        }
+        scheduleManager.loadScheduledActivities()
+        waitForExpectations(timeout: 2) { (err) in
+            print(String(describing: err))
+        }
+        
+        XCTAssertNil(scheduleManager.updateFailed_error)
+        XCTAssertNotNil(scheduleManager.update_fetchedActivities)
+        XCTAssertNotNil(scheduleManager.activityGroup)
+        XCTAssertEqual(scheduleManager.dayCount, 1)
+        XCTAssertTrue(scheduleManager.hasStudyBurst)
+        XCTAssertEqual(scheduleManager.finishedSchedules.count, 3)
+        XCTAssertTrue(scheduleManager.isCompletedForToday)
+        XCTAssertFalse(scheduleManager.isLastDay)
+        XCTAssertEqual(scheduleManager.calculateThisDay(), 1)
+        XCTAssertEqual(scheduleManager.pastSurveySchedules.count, 0)
+        XCTAssertNotNil(scheduleManager.todayCompletionTask)
+        
+        let demographics = scheduleManager.scheduledActivities.filter {
+            $0.activityIdentifier == RSDIdentifier.demographics.stringValue
+        }
+        XCTAssertEqual(demographics.count, 1)
+        
+        let studyBurstReminder = scheduleManager.scheduledActivities.filter {
+            $0.activityIdentifier == RSDIdentifier.studyBurstReminder.stringValue
+        }
+        XCTAssertEqual(studyBurstReminder.count, 1)
+        
+        XCTAssertNil(scheduleManager.actionBarItem)
+    }
+    
+    func testStudyBurstComplete_Day2_DemographicsNotFinished() {
+        
+        let scheduleManager = TestStudyBurstScheduleManager(.day2_demographicsNotFinished)
+        
+        let expect = expectation(description: "Update finished called.")
+        scheduleManager.updateFinishedBlock = {
+            expect.fulfill()
+        }
+        scheduleManager.loadScheduledActivities()
+        waitForExpectations(timeout: 2) { (err) in
+            print(String(describing: err))
+        }
+        
+        XCTAssertNil(scheduleManager.updateFailed_error)
+        XCTAssertNotNil(scheduleManager.update_fetchedActivities)
+        XCTAssertNotNil(scheduleManager.activityGroup)
+        XCTAssertEqual(scheduleManager.dayCount, 2)
+        XCTAssertTrue(scheduleManager.hasStudyBurst)
+        XCTAssertEqual(scheduleManager.finishedSchedules.count, 0)
+        XCTAssertFalse(scheduleManager.isCompletedForToday)
+        XCTAssertFalse(scheduleManager.isLastDay)
+        XCTAssertEqual(scheduleManager.calculateThisDay(), 2)
+        XCTAssertEqual(scheduleManager.pastSurveySchedules.count, 2)
+        XCTAssertNil(scheduleManager.todayCompletionTask)
+
+        let demographics = scheduleManager.scheduledActivities.filter {
+            $0.activityIdentifier == RSDIdentifier.demographics.stringValue
+        }
+        XCTAssertEqual(demographics.count, 1)
+        
+        let studyBurstReminder = scheduleManager.scheduledActivities.filter {
+            $0.activityIdentifier == RSDIdentifier.studyBurstReminder.stringValue
+        }
+        XCTAssertEqual(studyBurstReminder.count, 1)
+        
+        let completionTask = scheduleManager.completionTaskPath()
+        XCTAssertNotNil(completionTask)
+        
+        XCTAssertNotNil(scheduleManager.actionBarItem)
+        XCTAssertEqual(scheduleManager.actionBarItem?.title, "Health Survey")
+        XCTAssertEqual(scheduleManager.actionBarItem?.detail, "4 Minutes")
     }
     
     func testStudyBurstComplete_Day15_MissingOne() {
@@ -143,6 +231,10 @@ class StudyBurstTests: XCTestCase {
         
         let completionTask = scheduleManager.completionTaskPath()
         XCTAssertNotNil(completionTask)
+        
+        XCTAssertNotNil(scheduleManager.actionBarItem)
+        XCTAssertEqual(scheduleManager.actionBarItem?.title, "Engagement Survey")
+        XCTAssertEqual(scheduleManager.actionBarItem?.detail, "6 Minutes")
     }
     
     func testStudyBurstComplete_Day15_MissingTwo() {
@@ -169,6 +261,7 @@ class StudyBurstTests: XCTestCase {
         
         let completionTask = scheduleManager.completionTaskPath()
         XCTAssertNil(completionTask)
+        XCTAssertNil(scheduleManager.actionBarItem)
     }
     
     func testStudyBurstComplete_Day14_MissingOne() {
@@ -195,32 +288,7 @@ class StudyBurstTests: XCTestCase {
         
         let completionTask = scheduleManager.completionTaskPath()
         XCTAssertNil(completionTask)
-    }
-    
-    func testStudyBurstComplete_Day2_NoDemographics() {
-        
-        let scheduleManager = TestStudyBurstScheduleManager(.day2_demographicsNotFinished)
-        
-        let expect = expectation(description: "Update finished called.")
-        scheduleManager.updateFinishedBlock = {
-            expect.fulfill()
-        }
-        scheduleManager.loadScheduledActivities()
-        waitForExpectations(timeout: 2) { (err) in
-            print(String(describing: err))
-        }
-        
-        XCTAssertNil(scheduleManager.updateFailed_error)
-        XCTAssertNotNil(scheduleManager.update_fetchedActivities)
-        XCTAssertNotNil(scheduleManager.activityGroup)
-        XCTAssertEqual(scheduleManager.dayCount, 2)
-        XCTAssertTrue(scheduleManager.hasStudyBurst)
-        XCTAssertEqual(scheduleManager.finishedSchedules.count, 0)
-        XCTAssertFalse(scheduleManager.isCompletedForToday)
-        XCTAssertFalse(scheduleManager.isLastDay)
-        
-        let completionTask = scheduleManager.completionTaskPath()
-        XCTAssertNotNil(completionTask)
+        XCTAssertNil(scheduleManager.actionBarItem)
     }
     
     func testStudyBurstComplete_Day15_BurstComplete_EngagementNotComplete() {
@@ -246,6 +314,10 @@ class StudyBurstTests: XCTestCase {
         
         let completionTask = scheduleManager.completionTaskPath()
         XCTAssertNotNil(completionTask)
+        
+        XCTAssertNotNil(scheduleManager.actionBarItem)
+        XCTAssertEqual(scheduleManager.actionBarItem?.title, "Engagement Survey")
+        XCTAssertEqual(scheduleManager.actionBarItem?.detail, "6 Minutes")
     }
     
     func testStudyBurstComplete_Day15_BurstComplete_EngagementComplete() {
@@ -271,6 +343,8 @@ class StudyBurstTests: XCTestCase {
         
         let completionTask = scheduleManager.completionTaskPath()
         XCTAssertNil(completionTask)
+        
+        XCTAssertNil(scheduleManager.actionBarItem)
     }
 }
 


### PR DESCRIPTION
There are a lot of "what if" scenarios to support and I am basically trying to chip away at them in small chunks. This changes the logic for when to show a "survey" vs. the study burst.