### PR TITLE
use correct link for consent

### DIFF
--- a/mPower2/mPower2/AppDelegate.swift
+++ b/mPower2/mPower2/AppDelegate.swift
@@ -148,7 +148,7 @@ class AppDelegate: SBAAppDelegate, RSDTaskViewControllerDelegate {
         guard self.rootViewController?.state != .consent else { return }
         let vc = ConsentViewController()
         // TODO emm 2018-05-11 put this in BridgeInfo or AppConfig?
-        vc.url = URL(string: "http://mpower.sagebridge.org/")
+        vc.url = URL(string: "http://mpower.sagebridge.org/study/intro")
         self.transition(to: vc, state: .consent, animated: true)
     }
     

--- a/mPower2/mPower2/SignIn.json
+++ b/mPower2/mPower2/SignIn.json
@@ -77,7 +77,10 @@
                         "identifier":"preConsent",
                         "dataType":"singleChoice.boolean",
                         "uiHint":"checkbox",
-                        "choices":[ {"text":"pre-consented", "value":true }]
+                        "choices":[
+                                   {"text":"pre-consented", "value":true },
+                                   {"text":"test consent flow", "value":false }
+                                   ]
                     }
                 ],
                 "image":{


### PR DESCRIPTION
also “next” button on external ID sign-in page wouldn’t be enabled if you didn’t check the “pre-consented” checkbox so there was no way to test consent flow—so added a “test consent flow” checkbox to the single-choice bool item with a value “false”.

Fixes IA-710