### PR TITLE
update applinks

### DIFF
--- a/mPower2/mPower2/AppDelegate.swift
+++ b/mPower2/mPower2/AppDelegate.swift
@@ -93,7 +93,6 @@ class AppDelegate: SBAAppDelegate, RSDTaskViewControllerDelegate {
         }
         let components = url.pathComponents
         guard components.count == 4,
-            url.host! == "ws.sagebridge.org",
             components[1] == BridgeSDK.bridgeInfo.studyIdentifier,
             components[2] == "phoneSignIn"
             else {

--- a/mPower2/mPower2/mPower2.entitlements
+++ b/mPower2/mPower2/mPower2.entitlements
@@ -5,6 +5,8 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:ws.sagebridge.org</string>
+		<string>applinks:parkinsonmpower.org</string>
+		<string>applinks:mpower.sagebridge.org</string>
 	</array>
 	<key>com.apple.developer.default-data-protection</key>
 	<string>NSFileProtectionComplete</string>


### PR DESCRIPTION
to handle transition to web consent site for “you need to install the app” landing pages, via internal URL for now and public URL once IRB approved