### PR TITLE
Revert "temporarily disable archive builds"

### DIFF
--- a/travis/build.sh
+++ b/travis/build.sh
@@ -7,13 +7,11 @@ elif [[ -z "$TRAVIS_TAG" && "$TRAVIS_BRANCH" == "master" ]]; then  # non-tag com
     echo "Build on merge to master"
     git clone https://github.com/Sage-Bionetworks/iOSPrivateProjectInfo.git ../iOSPrivateProjectInfo
     FASTLANE_EXPLICIT_OPEN_SIMULATOR=2 bundle exec fastlane test project:"mPower2/mPower2.xcodeproj" scheme:"mPower2"
-# temporarily disable archive build due to https://github.com/fastlane/fastlane/issues/13186
-#    bundle exec fastlane ci_archive scheme:"mPower2" export_method:"app-store" project:"mPower2/mPower2.xcodeproj"
+    bundle exec fastlane ci_archive scheme:"mPower2" export_method:"app-store" project:"mPower2/mPower2.xcodeproj"
 elif [[ -z "$TRAVIS_TAG" && "$TRAVIS_BRANCH" =~ ^stable-.* ]]; then # non-tag commits to stable branches
     echo "Build on stable branch"
     git clone https://github.com/Sage-Bionetworks/iOSPrivateProjectInfo.git ../iOSPrivateProjectInfo
     FASTLANE_EXPLICIT_OPEN_SIMULATOR=2 bundle exec fastlane test project:"mPower2/mPower2.xcodeproj" scheme:"mPower2"
-# temporarily disable archive build due to https://github.com/fastlane/fastlane/issues/13186
-#    bundle exec fastlane beta scheme:"mPower2" export_method:"app-store" project:"mPower2/mPower2.xcodeproj"
+    bundle exec fastlane beta scheme:"mPower2" export_method:"app-store" project:"mPower2/mPower2.xcodeproj"
 fi
 exit $?


### PR DESCRIPTION
This reverts commit b62a44687da75281f443697874f928ad926c7427.
archive build is fixed, the problem was an incompatible openssl.
https://github.com/fastlane/fastlane/issues/13242