### PR TITLE
Add 5 second countdown to the tremor test

### DIFF
--- a/mPower2/MotorControl/Resources/TremorSectionStep.json
+++ b/mPower2/MotorControl/Resources/TremorSectionStep.json
@@ -39,6 +39,25 @@
                     }
               },
               {
+                  "identifier":"countdown",
+                  "type":"countdown",
+                  "text":"Begin in...",
+                  "image":{
+                      "type":"fetchable",
+                      "imageName":"HoldPhone-Left",
+                      "placementType":"fullsizeBackground"
+                  },
+                  "viewTheme":{
+                      "viewIdentifier":"Countdown",
+                      "storyboardIdentifier":"ActiveTaskSteps"
+                  },
+                  "colorTheme":{
+                      "usesLightStyle":true
+                  },
+                  "duration":5,
+                  "commands":["playSoundOnStart", "transitionAutomatically"]
+              },
+              {
                   "identifier":"tremor",
                   "type":"active",
                   "duration":30,

--- a/mPower2/MotorControl/ViewControllers/MCTCountdownStepViewController.swift
+++ b/mPower2/MotorControl/ViewControllers/MCTCountdownStepViewController.swift
@@ -36,13 +36,25 @@ import Foundation
 extension MCTCountdownStepViewController : MCTInternalStepController {
 }
 
-open class MCTCountdownStepViewController : RSDCountdownStepViewController {
+open class MCTCountdownStepViewController : RSDCountdownStepViewController, MCTHandStepController {
     
+    /// Retuns the imageView, in this case the image from the navigationHeader.
+    public var imageView: UIImageView? {
+        return self.navigationHeader?.imageView ?? self.navigationBody?.imageView
+    }
     
     /// Override show learn more to insert the first run answer result.
     override open func showLearnMore() {
         // Update the first run to show the full instructions.
         setIsFirstRunResult(true)
         super.showLearnMore()
+    }
+    
+    /// Override viewWillAppear to also set the unitLabel text.
+    override open func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.updateImage()
+        self.view.setNeedsLayout()
+        self.view.setNeedsUpdateConstraints()
     }
 }


### PR DESCRIPTION
Note: this also requires implementing flipping the image for the right hand.

@Robert-Kolmos This will need to be updated on Android.

https://sagebionetworks.jira.com/browse/IA-776