### PR TITLE
handle 412 Not Consented Bridge responses

### DIFF
--- a/mPower2/mPower2/AppDelegate.swift
+++ b/mPower2/mPower2/AppDelegate.swift
@@ -41,8 +41,6 @@ class AppDelegate: SBAAppDelegate, RSDTaskViewControllerDelegate {
     
     weak var smsSignInDelegate: SignInDelegate? = nil
     
-    var userSessionInfo: SBBUserSessionInfo?
-    
     override func instantiateFactory() -> RSDFactory {
         return MP2Factory()
     }
@@ -52,13 +50,6 @@ class AppDelegate: SBAAppDelegate, RSDTaskViewControllerDelegate {
     }
     
     override func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey : Any]?) -> Bool {
-        NotificationCenter.default.addObserver(forName: .sbbUserSessionUpdated, object: nil, queue: .main) { (notification) in
-            guard let info = notification.userInfo?[kSBBUserSessionInfoKey] as? SBBUserSessionInfo else {
-                fatalError("Expected notification userInfo to contain a user session info object")
-            }
-            self.userSessionInfo = info
-        }
-        
         SBASurveyConfiguration.shared = MP2SurveyConfiguration()
         
         // Instantiate and load the scheduled activities and reports for the study burst.
@@ -79,7 +70,7 @@ class AppDelegate: SBAAppDelegate, RSDTaskViewControllerDelegate {
     
     func showAppropriateViewController(animated: Bool) {
         if BridgeSDK.authManager.isAuthenticated() {
-            if userSessionInfo?.consentedValue ?? false {
+            if SBAParticipantManager.shared.isConsented {
                 showMainViewController(animated: animated)
             } else {
                 showConsentViewController(animated: animated)
@@ -208,6 +199,13 @@ class AppDelegate: SBAAppDelegate, RSDTaskViewControllerDelegate {
     
     func taskController(_ taskController: RSDTaskController, asyncActionControllerFor configuration: RSDAsyncActionConfiguration) -> RSDAsyncActionController? {
         return nil
+    }
+    
+    // MARK: SBBBridgeErrorUIDelegate
+    
+    override func handleUserNotConsentedError(_ error: Error, sessionInfo: Any, networkManager: SBBNetworkManagerProtocol?) -> Bool {
+        self.showConsentViewController(animated: true);
+        return true;
     }
     
 }

--- a/mPower2/mPower2/ProfileTableItems.swift
+++ b/mPower2/mPower2/ProfileTableItems.swift
@@ -111,8 +111,7 @@ class StudyParticipationProfileTableItem: SBAProfileTableItemBase {
 
     override open var detail: String {
         get {
-            let appDelegate = AppDelegate.shared as! AppDelegate
-            let enrolled = appDelegate.userSessionInfo?.consentedValue ?? false
+            let enrolled = SBAParticipantManager.shared.isConsented
             let key = enrolled ? "PARTICIPATION_ENROLLED_%@" : "PARTICIPATION_REJOIN_%@"
             let format = Localization.localizedString(key)
             return String.localizedStringWithFormat(format, Localization.localizedAppName)

--- a/mPower2/mPower2TestApp/ActivityManager.swift
+++ b/mPower2/mPower2TestApp/ActivityManager.swift
@@ -350,7 +350,7 @@ public struct SurveyReference : Codable {
     let createdOn: String
     
     static var all: [SurveyReference] = {
-        let surveyIdentifiers = ["Demographics", "Engagement", "Motivation", "Background", "Withdrawl"]
+        let surveyIdentifiers = ["Demographics", "Engagement", "Motivation", "Background", "Withdrawal"]
         let surveys: [SurveyReference] = surveyIdentifiers.compactMap {
             do {
                 let transformer = RSDResourceTransformerObject(resourceName: $0)


### PR DESCRIPTION
also use SBAParticipantManager’s new isConsented flag instead of getting it ourselves

requires https://github.com/Sage-Bionetworks/BridgeApp-Apple-SDK/pull/97