### PR TITLE
Include calculated gravity vector and user acceleration

### DIFF
--- a/mPower2/MotorControl/Resources/TappingSectionStep.json
+++ b/mPower2/MotorControl/Resources/TappingSectionStep.json
@@ -7,7 +7,7 @@
                          "identifier":"motion",
                          "type":"motion",
                          "requiresBackgroundAudio":true,
-                         "recorderTypes":["accelerometer", "gyro"]
+                         "recorderTypes": ["accelerometer", "gyro", "gravity", "userAcceleration"]
                      }
                     ],
      "steps":[

--- a/mPower2/MotorControl/Resources/TappingSectionStep.json
+++ b/mPower2/MotorControl/Resources/TappingSectionStep.json
@@ -7,7 +7,7 @@
                          "identifier":"motion",
                          "type":"motion",
                          "requiresBackgroundAudio":true,
-                         "recorderTypes": ["accelerometer", "gyro", "gravity", "userAcceleration"]
+                         "recorderTypes": ["accelerometer", "gyro", "gravity", "userAcceleration", "attitude", "rotationRate"]
                      }
                     ],
      "steps":[

--- a/mPower2/MotorControl/Resources/TremorSectionStep.json
+++ b/mPower2/MotorControl/Resources/TremorSectionStep.json
@@ -6,7 +6,7 @@
                          "identifier":"motion",
                          "type":"motion",
                          "requiresBackgroundAudio":true,
-                         "recorderTypes":["accelerometer", "gyro"]
+                         "recorderTypes":["accelerometer", "gyro", "gravity", "userAcceleration"]
                      }
                     ],
      "steps":[

--- a/mPower2/MotorControl/Resources/TremorSectionStep.json
+++ b/mPower2/MotorControl/Resources/TremorSectionStep.json
@@ -6,7 +6,7 @@
                          "identifier":"motion",
                          "type":"motion",
                          "requiresBackgroundAudio":true,
-                         "recorderTypes":["accelerometer", "gyro", "gravity", "userAcceleration"]
+                         "recorderTypes":["accelerometer", "gyro", "gravity", "userAcceleration", "attitude", "rotationRate"]
                      }
                     ],
      "steps":[

--- a/mPower2/MotorControl/Resources/Walk_And_Balance.json
+++ b/mPower2/MotorControl/Resources/Walk_And_Balance.json
@@ -201,7 +201,7 @@
                                      "identifier":"motion",
                                      "type":"motion",
                                      "requiresBackgroundAudio":true,
-                                     "recorderTypes": ["accelerometer", "gyro", "gravity", "userAcceleration"]
+                                     "recorderTypes": ["accelerometer", "gyro", "gravity", "userAcceleration", "attitude", "rotationRate"]
                                  }
                                 ],
                  "steps":[
@@ -337,7 +337,7 @@
                                  "identifier":"motion",
                                  "type":"motion",
                                  "requiresBackgroundAudio":true,
-                                 "recorderTypes": ["accelerometer", "gyro", "gravity", "userAcceleration"]
+                                 "recorderTypes": ["accelerometer", "gyro", "gravity", "userAcceleration", "attitude", "rotationRate"]
                                  }
                                  ],
                  "steps":[

--- a/mPower2/MotorControl/Resources/Walk_And_Balance.json
+++ b/mPower2/MotorControl/Resources/Walk_And_Balance.json
@@ -201,7 +201,7 @@
                                      "identifier":"motion",
                                      "type":"motion",
                                      "requiresBackgroundAudio":true,
-                                     "recorderTypes":["accelerometer", "gyro"]
+                                     "recorderTypes": ["accelerometer", "gyro", "gravity", "userAcceleration"]
                                  }
                                 ],
                  "steps":[
@@ -337,10 +337,7 @@
                                  "identifier":"motion",
                                  "type":"motion",
                                  "requiresBackgroundAudio":true,
-                                 "recorderTypes":[
-                                                  "accelerometer",
-                                                  "gyro"
-                                                  ]
+                                 "recorderTypes": ["accelerometer", "gyro", "gravity", "userAcceleration"]
                                  }
                                  ],
                  "steps":[


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/MPOW-162

I cannot test this on my phone to test (b/c my phone is on iOS 12) but this change should include gravity and userAcceleration calculated "sensors". 

Note: By pushing to stable, we can release a version that does not include the refactoring that should probably go through a full testing.