### PR TITLE
Fixes MP2-195

### DIFF
--- a/mPower2/mPower2/TaskGroupScheduleManager.swift
+++ b/mPower2/mPower2/TaskGroupScheduleManager.swift
@@ -181,7 +181,7 @@ public class TaskGroupScheduleManager : ActivityGroupScheduleManager {
         // complete the task.
         var passiveDataPermissionStep: RSDSubtaskStepObject? = nil
         if taskInfo.identifier == .walkAndBalanceTask,
-                SBAProfileManagerObject.shared.value(forProfileKey: RSDIdentifier.passiveDataPermission.rawValue) == nil {
+                SBAProfileManagerObject.shared.value(forProfileKey: RSDIdentifier.passiveDataPermissionProfileKey.rawValue) == nil {
             let passiveInfo = RSDTaskInfoObject(with: RSDIdentifier.passiveDataPermission.rawValue)
             let passiveInfoStep = RSDTaskInfoStepObject(with: passiveInfo)
             let navSteps = [passiveInfoStep]


### PR DESCRIPTION
was checking the wrong profile key to see if they’d already been asked about passive data permission, so it would show the request after every walk-and-balance test.