### PR TITLE
Study burst notifications

### DIFF
--- a/mPower2/mPower2/BridgeInfo.plist
+++ b/mPower2/mPower2/BridgeInfo.plist
@@ -11,7 +11,7 @@
 	<key>appUpdateURL</key>
 	<string>https://notsupported.null</string>
 	<key>cacheDaysAhead</key>
-	<integer>104</integer>
+	<integer>180</integer>
 	<key>cacheDaysBehind</key>
 	<integer>730</integer>
 </dict>

--- a/mPower2/mPower2/StudyBurstScheduleManager.swift
+++ b/mPower2/mPower2/StudyBurstScheduleManager.swift
@@ -736,9 +736,9 @@ class StudyBurstScheduleManager : TaskGroupScheduleManager {
         }
         
         // If getting near the end, then add next cycle.
-        if futureSchedules.count <= extraDays {
+        if futureSchedules.count <= self.studyBurst.numberOfDays {
             let taskPredicate = SBBScheduledActivity.activityIdentifierPredicate(with: self.studyBurst.identifier)
-            let start = startOfToday.addingNumberOfDays(2 * extraDays)
+            let start = startOfToday.addingNumberOfDays(self.maxDaysCount)
             let end = start.addingNumberOfYears(1)
             let studyMarkerPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
                 SBBScheduledActivity.availablePredicate(from: start, to: end),
@@ -787,7 +787,7 @@ class StudyBurstScheduleManager : TaskGroupScheduleManager {
         // Set up the notification
         let content = UNMutableNotificationContent()
         // TODO: syoung 07/19/2018 Figure out what the wording of the notification should be.
-        content.body = "Time to do your mPower Study Burst activities!"
+        content.body = NSLocalizedString("Time to do your mPower Study Burst activities!", comment: "Notification message")
         content.sound = UNNotificationSound.default
         content.badge = UIApplication.shared.applicationIconBadgeNumber + 1 as NSNumber;
         content.categoryIdentifier = self.notificationCategory


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/MP2-213

Increased the cached days ahead and the number of notifications used by the Study Burst. This does run the risk of causing some of the meds reminders to be swallowed (and or the study Burst reminders depending upon which are set up first) because of the 60 notification limit.