### PR TITLE
update mini_magick lib

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,7 @@ GEM
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2018.0812)
-    mini_magick (4.9.4)
+    mini_magick (4.9.5)
     multi_json (1.13.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,7 @@ GEM
       google-api-client (>= 0.21.2, < 0.24.0)
       highline (>= 1.7.2, < 2.0.0)
       json (< 3.0.0)
-      mini_magick (~> 4.5.1)
+      mini_magick (>= 4.9.4, < 5.0.0)
       multi_json
       multi_xml (~> 0.5)
       multipart-post (~> 2.0.0)
@@ -88,7 +88,7 @@ GEM
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2018.0812)
-    mini_magick (4.5.1)
+    mini_magick (4.9.4)
     multi_json (1.13.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)


### PR DESCRIPTION
Github reported a security vulnerablility and says we should
update mini_magick to 4.9.4.