### PR TITLE
MP2-239 alt displacement

### DIFF
--- a/mPower2/mPower2/PassiveCollectors.swift
+++ b/mPower2/mPower2/PassiveCollectors.swift
@@ -215,7 +215,11 @@ class PassiveDisplacementCollector : NSObject, PassiveLocationTriggeredCollector
             try archive.complete()
             archive.encryptAndUploadArchive()
         }
-        catch {}
+        catch let error {
+            #if DEBUG
+            print("Error preparing passive displacement data for upload: \(error)")
+            #endif
+        }
    }
     
     // MARK: CLLocationManagerDelegate
@@ -811,7 +815,11 @@ class PassiveGaitCollector : NSObject, PassiveLocationTriggeredCollector {
             try archive.complete()
             archive.encryptAndUploadArchive()
         }
-        catch {}
+        catch let error {
+            #if DEBUG
+            print("Error preparing passive displacement geofence data for upload: \(error)")
+            #endif
+        }
     }
     
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {

--- a/mPower2/mPower2/PassiveCollectors.swift
+++ b/mPower2/mPower2/PassiveCollectors.swift
@@ -220,7 +220,7 @@ class PassiveDisplacementCollector : NSObject, PassiveLocationTriggeredCollector
     
     // MARK: CLLocationManagerDelegate
     func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
-        if status == .authorizedAlways {
+        if status == .authorizedAlways || status == .authorizedWhenInUse {
             // Hey we have permission now, yay! so (re)start monitoring.
             start()
         } else {
@@ -755,7 +755,7 @@ class PassiveGaitCollector : NSObject, PassiveLocationTriggeredCollector {
     }
     
     func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
-        if status == .authorizedAlways {
+        if status == .authorizedAlways || status == .authorizedWhenInUse {
             // Hey we have permission now, yay! so (re)start monitoring.
             startLocationServices()
         } else {


### PR DESCRIPTION
Log displacement based on geofences

With the location manager geofencing trick the passive gait task uses to activate passive motion sensor logging, it looks like maybe we can piggyback on that to get better passive displacement data by logging a displacement to Bridge whenever we set a geofence (vs. using significant location changes, which are unpredictable and undependable). We’ll log it to a separate schema so the data analysts can compare the two methods and see which, if either, really is better.

Also, deal with iOS 13's changed approach to requesting location permissions. See https://medium.com/better-programming/understanding-new-location-permission-changes-in-ios-13-6c34dc5f54da for details.