### PR TITLE
Belt and suspenders. Always return an activity group.

### DIFF
--- a/mPower2/mPower2/StudyBurstScheduleManager.swift
+++ b/mPower2/mPower2/StudyBurstScheduleManager.swift
@@ -130,8 +130,10 @@ class StudyBurstScheduleManager : TaskGroupScheduleManager {
     /// Return the activity group set by the navigator.
     override public var activityGroup: SBAActivityGroup? {
         get {
-            guard let groupId = studyBurst?.taskGroupIdentifier.stringValue else { return nil }
-            return configuration.activityGroup(with: groupId)
+            let studyBurst = self.studyBurst ?? StudyBurstConfiguration()
+            let groupId = studyBurst.taskGroupIdentifier.stringValue
+            let activityGroup = configuration.activityGroup(with: groupId)
+            return activityGroup ?? DataSourceManager.shared.activityGroup(with: .measuringTaskGroup)
         }
         set {
             // Do nothing

--- a/mPower2/mPower2/StudyBurstScheduleManager.swift
+++ b/mPower2/mPower2/StudyBurstScheduleManager.swift
@@ -133,7 +133,14 @@ class StudyBurstScheduleManager : TaskGroupScheduleManager {
             let studyBurst = self.studyBurst ?? StudyBurstConfiguration()
             let groupId = studyBurst.taskGroupIdentifier.stringValue
             let activityGroup = configuration.activityGroup(with: groupId)
-            return activityGroup ?? DataSourceManager.shared.activityGroup(with: .measuringTaskGroup)
+            return activityGroup ?? SBAActivityGroupObject(identifier: groupId,
+                                                           title: Localization.localizedString(groupId),
+                                                           journeyTitle: nil,
+                                                           image: nil,
+                                                           activityIdentifiers: RSDIdentifier.measuringTasks,
+                                                           notificationIdentifier: nil,
+                                                           schedulePlanGuid: nil,
+                                                           activityGuidMap: nil)
         }
         set {
             // Do nothing


### PR DESCRIPTION
Note: this will fail in the case where the measurement tasks are changed via the app config to be something different from the hardcoded list.