### PR TITLE
Refresh data groups

### DIFF
--- a/MobileToolboxWrapper/MobileToolboxWrapper.xcodeproj/project.pbxproj
+++ b/MobileToolboxWrapper/MobileToolboxWrapper.xcodeproj/project.pbxproj
@@ -21,12 +21,16 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		FF762ACE276037A600FA1D8F /* BridgeSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FF762ACD276037A600FA1D8F /* BridgeSDK.framework */; };
+		FF762AD227603A1500FA1D8F /* MTBDataArchive.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF762AD127603A1500FA1D8F /* MTBDataArchive.swift */; };
 		FF79502F273A0252007F6269 /* MobileToolboxWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = FF79502E273A0252007F6269 /* MobileToolboxWrapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FF795038273A0342007F6269 /* MobileToolboxKit in Frameworks */ = {isa = PBXBuildFile; productRef = FF795037273A0342007F6269 /* MobileToolboxKit */; };
 		FF79503A273A03BA007F6269 /* MobileToolboxWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF795039273A03BA007F6269 /* MobileToolboxWrapper.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		FF762ACD276037A600FA1D8F /* BridgeSDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = BridgeSDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		FF762AD127603A1500FA1D8F /* MTBDataArchive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MTBDataArchive.swift; sourceTree = "<group>"; };
 		FF79502B273A0252007F6269 /* MobileToolboxWrapper.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MobileToolboxWrapper.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FF79502E273A0252007F6269 /* MobileToolboxWrapper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MobileToolboxWrapper.h; sourceTree = "<group>"; };
 		FF795039273A03BA007F6269 /* MobileToolboxWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileToolboxWrapper.swift; sourceTree = "<group>"; };
@@ -38,6 +42,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FF762ACE276037A600FA1D8F /* BridgeSDK.framework in Frameworks */,
 				FF795038273A0342007F6269 /* MobileToolboxKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -67,6 +72,7 @@
 			children = (
 				FF79502E273A0252007F6269 /* MobileToolboxWrapper.h */,
 				FF795039273A03BA007F6269 /* MobileToolboxWrapper.swift */,
+				FF762AD127603A1500FA1D8F /* MTBDataArchive.swift */,
 			);
 			path = MobileToolboxWrapper;
 			sourceTree = "<group>";
@@ -74,6 +80,7 @@
 		FF795036273A0342007F6269 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				FF762ACD276037A600FA1D8F /* BridgeSDK.framework */,
 				FFCEF4A72756B01F00D376E6 /* ResearchV2.framework */,
 			);
 			name = Frameworks;
@@ -189,6 +196,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FF762AD227603A1500FA1D8F /* MTBDataArchive.swift in Sources */,
 				FF79503A273A03BA007F6269 /* MobileToolboxWrapper.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/MobileToolboxWrapper/MobileToolboxWrapper/MTBDataArchive.swift
+++ b/MobileToolboxWrapper/MobileToolboxWrapper/MTBDataArchive.swift
@@ -1,0 +1,193 @@
+//
+//  MTBDataArchive.swift
+//  MobileToolboxWrapper
+//
+//
+//  Copyright © 2016-2021 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import Foundation
+import JsonModel
+import Research
+import BridgeSDK
+
+private let kDataGroups                       = "dataGroups"
+private let kSchemaRevisionKey                = "schemaRevision"
+private let kMetadataFilename                 = "metadata.json"
+
+class MTBArchiveManager : NSObject, RSDDataArchiveManager {
+    
+    static let shared = MTBArchiveManager()
+    
+    /// A serial queue used to manage data crunching.
+    let offMainQueue = DispatchQueue(label: "org.sagebionetworks.MobileToolboxWrapper.MTBArchiveManager")
+    
+    func archiveAndUpload(taskState: RSDTaskViewModel, schemaIdentifier: String, schemaRevision: Int?, dataGroups: Set<String>?) {
+        let uuid = taskState.taskRunUUID ?? UUID()
+        self._retainedPaths[uuid] = taskState
+        self._schemaIdentifierMap[uuid] = schemaIdentifier
+        self._schemaRevisionMap[uuid] = schemaRevision
+        self._dataGroupsMap[uuid] = dataGroups
+        offMainQueue.async {
+            taskState.archiveResults(with: self) { (_ error: Error?) in
+                self._retainedPaths[uuid] = nil
+            }
+        }
+    }
+    private var _retainedPaths: [UUID : RSDTaskViewModel] = [:]
+    private var _schemaIdentifierMap: [UUID : String] = [:]
+    private var _schemaRevisionMap: [UUID : Int] = [:]
+    private var _dataGroupsMap: [UUID : Set<String>] = [:]
+    
+    func shouldContinueOnFail(for archive: RSDDataArchive, error: Error) -> Bool {
+        debugPrint("ERROR! Failed to archive results: \(error)")
+        // Flush the archive.
+        (archive as? SBBDataArchive)?.remove()
+        return false
+    }
+    
+    func dataArchiver(for taskResult: RSDTaskResult, scheduleIdentifier: String?, currentArchive: RSDDataArchive?) -> RSDDataArchive? {
+        guard currentArchive == nil,
+                let topResult = taskResult as? AssessmentResult
+        else {
+            return currentArchive
+        }
+        
+        // Look for a schema info associated with this portion of the task result. If not found, then
+        // return the current archive.
+        let uuid = topResult.taskRunUUID
+        let schemaIdentifier = _schemaIdentifierMap[uuid]
+        let archiveIdentifier = schemaIdentifier ?? taskResult.identifier
+        let schemaRevision = _schemaRevisionMap[uuid]
+        let dataGroups = _dataGroupsMap[uuid]
+        
+        return MTBDataArchive(identifier: archiveIdentifier,
+                              schemaIdentifier: schemaIdentifier,
+                              schemaRevision: schemaRevision ?? 1,
+                              dataGroups: dataGroups)
+    }
+    
+    /// Finalize the upload of all the created archives.
+    public final func encryptAndUpload(taskResult: RSDTaskResult, dataArchives: [RSDDataArchive], completion:@escaping (() -> Void)) {
+        let archives: [SBBDataArchive] = dataArchives.compactMap {
+            guard let archive = $0 as? SBBDataArchive, self.shouldUpload(archive: archive) else { return nil }
+            return archive
+        }
+        SBBDataArchive.encryptAndUploadArchives(archives)
+        completion()
+    }
+    
+    /// This method is called during `encryptAndUpload()` to allow subclasses to cancel uploading an archive.
+    ///
+    /// - returns: Whether or not to upload. Default is to return `true` if the archive is not empty.
+    open func shouldUpload(archive: SBBDataArchive) -> Bool {
+        return !archive.isEmpty()
+    }
+    
+    /// By default, if an archive fails, the error is printed and that's all that is done.
+    open func handleArchiveFailure(taskResult: RSDTaskResult, error: Error, completion:@escaping (() -> Void)) {
+        debugPrint("WARNING! Failed to archive \(taskResult.identifier). \(error)")
+        completion()
+    }
+}
+
+class MTBDataArchive: SBBDataArchive, RSDDataArchive {
+
+    /// The identifier for this archive.
+    let identifier: String
+    
+    /// Store the task groups
+    let dataGroups: Set<String>?
+    
+    /// Does not support schedules.
+    var scheduleIdentifier: String? { nil }
+    
+    init(identifier: String, schemaIdentifier: String?, schemaRevision: Int, dataGroups: Set<String>?) {
+        self.identifier = identifier
+        self.dataGroups = dataGroups
+        super.init(reference: schemaIdentifier ?? identifier, jsonValidationMapping: nil)
+        
+        // set info values.
+        self.setArchiveInfoObject(NSNumber(value: schemaRevision), forKey: kSchemaRevisionKey)
+    }
+    
+    /// By default, the task result is not included and metadata are **not** archived directly, while the
+    /// answer map is included.
+    open func shouldInsertData(for filename: RSDReservedFilename) -> Bool {
+        return true
+    }
+    
+    /// Get the archivable object for the given result.
+    open func archivableData(for result: ResultData, sectionIdentifier: String?, stepPath: String?) -> RSDArchivable? {
+        result as? RSDArchivable
+    }
+    
+    /// Insert the data into the archive. By default, this will call `insertData(intoArchive:,filename:, createdOn:)`.
+    ///
+    /// - note: The "answers.json" file is special-cased to *not* include the `.json` extension if this is
+    /// for a `v1_legacy` archive. This allows the v1 schema to use `answers.foo` which reads better in the
+    /// Synapse tables.
+    open func insertDataIntoArchive(_ data: Data, manifest: RSDFileManifest) throws {
+        let filename = manifest.filename
+        let fileKey = (filename as NSString).deletingPathExtension
+        if let reserved = RSDReservedFilename(rawValue: fileKey), reserved == .answers {
+            self.dataFilename = filename
+        }
+        self.insertData(intoArchive: data, filename: filename, createdOn: manifest.timestamp)
+        
+        if filename == "taskData" {
+            self.insertData(intoArchive: data, filename: "\(filename).json", createdOn: manifest.timestamp)
+        }
+    }
+    
+    /// Close the archive.
+    open func completeArchive(with metadata: RSDTaskMetadata) throws {
+        let metadataDictionary = try metadata.rsd_jsonEncodedDictionary()
+        try completeArchive(createdOn: metadata.startDate, with: metadataDictionary)
+    }
+    
+    /// Close the archive with optional metadata from a task result.
+    open func completeArchive(createdOn: Date, with metadata: [String : Any]? = nil) throws {
+
+        // Set up the activity metadata.
+        var metadataDictionary: [String : Any] = metadata ?? [:]
+        
+        // Add the current data groups.
+        if let dataGroups = self.dataGroups {
+            metadataDictionary[kDataGroups] = dataGroups.joined(separator: ",")
+        }
+        
+        // insert the dictionary.
+        insertDictionary(intoArchive: metadataDictionary, filename: kMetadataFilename, createdOn: createdOn)
+        
+        // complete the archive.
+        try complete()
+    }
+}
+

--- a/MobileToolboxWrapper/MobileToolboxWrapper/MTBDataArchive.swift
+++ b/MobileToolboxWrapper/MobileToolboxWrapper/MTBDataArchive.swift
@@ -94,7 +94,7 @@ class MTBArchiveManager : NSObject, RSDDataArchiveManager {
     }
     
     /// Finalize the upload of all the created archives.
-    public final func encryptAndUpload(taskResult: RSDTaskResult, dataArchives: [RSDDataArchive], completion:@escaping (() -> Void)) {
+    func encryptAndUpload(taskResult: RSDTaskResult, dataArchives: [RSDDataArchive], completion:@escaping (() -> Void)) {
         let archives: [SBBDataArchive] = dataArchives.compactMap {
             guard let archive = $0 as? SBBDataArchive, self.shouldUpload(archive: archive) else { return nil }
             return archive
@@ -106,12 +106,12 @@ class MTBArchiveManager : NSObject, RSDDataArchiveManager {
     /// This method is called during `encryptAndUpload()` to allow subclasses to cancel uploading an archive.
     ///
     /// - returns: Whether or not to upload. Default is to return `true` if the archive is not empty.
-    open func shouldUpload(archive: SBBDataArchive) -> Bool {
+    func shouldUpload(archive: SBBDataArchive) -> Bool {
         return !archive.isEmpty()
     }
     
     /// By default, if an archive fails, the error is printed and that's all that is done.
-    open func handleArchiveFailure(taskResult: RSDTaskResult, error: Error, completion:@escaping (() -> Void)) {
+    func handleArchiveFailure(taskResult: RSDTaskResult, error: Error, completion:@escaping (() -> Void)) {
         debugPrint("WARNING! Failed to archive \(taskResult.identifier). \(error)")
         completion()
     }

--- a/MobileToolboxWrapper/MobileToolboxWrapper/MTBDataArchive.swift
+++ b/MobileToolboxWrapper/MobileToolboxWrapper/MTBDataArchive.swift
@@ -122,7 +122,7 @@ class MTBDataArchive: SBBDataArchive, RSDDataArchive {
     /// The identifier for this archive.
     let identifier: String
     
-    /// Store the task groups
+    /// Store the task groups.
     let dataGroups: Set<String>?
     
     /// Does not support schedules.

--- a/mPower2/mPower2/AppDelegate.swift
+++ b/mPower2/mPower2/AppDelegate.swift
@@ -162,6 +162,14 @@ class AppDelegate: SBAAppDelegate, RSDTaskViewControllerDelegate {
                             if (error as NSError?)?.code == SBBErrorCode.serverPreconditionNotMet.rawValue {
                                 self.showConsentViewController(animated: true)
                             } else if error == nil {
+                                
+                                // Now that we have a user who is signed in via phone number, check the region code to
+                                // see if we need to add the heart snapshot data group.
+                                // Heart Snapshot tasks are only enabled for the Netherlands region
+                                if (regionCode == SignInTaskViewController.NETHERLANDS_REGION_CODE) {
+                                    BridgeSDK.participantManager.add(toDataGroups: ["show_heartsnapshot"], completion: nil)
+                                }
+                                
                                 self.showAppropriateViewController(animated: true)
                             } else {
                                 #if DEBUG
@@ -207,6 +215,11 @@ class AppDelegate: SBAAppDelegate, RSDTaskViewControllerDelegate {
             else {
             fatalError("Failed to instantiate initial view controller in the main storyboard.")
         }
+        
+        // Check that the engagement groups have been set before transitioning.
+        StudyBurstScheduleManager.shared.setEngagementGroupsIfNeeded()
+        
+        // Show the main view controller.
         self.transition(to: vc, state: .main, animated: true)
         
         // start the passive collectors now in case they weren't started at launch

--- a/mPower2/mPower2/ExternalIDRegistrationViewController.swift
+++ b/mPower2/mPower2/ExternalIDRegistrationViewController.swift
@@ -69,11 +69,6 @@ class ExternalIDRegistrationViewController: RSDTableStepViewController {
         if credentials.preconsent {
             dataGroups.insert("test_no_consent")
         }
-        // Assign the engagement data groups.
-        if let engagementGroups = (SBABridgeConfiguration.shared as? MP2BridgeConfiguration)?.studyBurst.randomEngagementGroups() {
-            dataGroups.formUnion(engagementGroups)
-        }
-        signUp.dataGroups = dataGroups
         
         BridgeSDK.authManager.signUpStudyParticipant(signUp, completion: { (task, result, error) in
             guard error == nil else {
@@ -83,6 +78,10 @@ class ExternalIDRegistrationViewController: RSDTableStepViewController {
             
             // we're signed up so sign in
             BridgeSDK.authManager.signIn(withExternalId: signUp.externalId!, password: signUp.password!, completion: { (task, result, error) in
+                
+                // Once we are signed in, add the data groups (if needed).
+                BridgeSDK.participantManager.add(toDataGroups: dataGroups, completion: nil)
+                
                 completion(task, result, error)
             })
         })

--- a/mPower2/mPower2/HistoryDataManager.swift
+++ b/mPower2/mPower2/HistoryDataManager.swift
@@ -79,7 +79,10 @@ class HistoryDataManager : SBAReportManager {
     /// changed today. It also looks at past reports if and only if it needs to add them to the
     /// local store.
     override func reportQueries() -> [ReportQuery] {
-        let tasks = Set(RSDIdentifier.dataTrackingTasks).union(RSDIdentifier.measuringTasks).union([RSDIdentifier.heartSnapshotTask])
+        let tasks = Set(RSDIdentifier.dataTrackingTasks)
+            .union(RSDIdentifier.measuringTasks)
+            .union([RSDIdentifier.heartSnapshotTask])
+            .union([RSDIdentifier.cognitionTask])
         if persistentContainer == nil {
             return tasks.map { ReportQuery(reportKey: $0, queryType: .today, dateRange: nil) }
         }
@@ -239,6 +242,12 @@ class HistoryDataManager : SBAReportManager {
             item.imageName = "TremorTaskIcon"
             return item
             
+        case .cognitionTask:
+            let item = MeasurementHistoryItem(context: context, report: report)
+            item.title = Localization.localizedString("HISTORY_ITEM_COGNITION_TITLE")
+            item.imageName = "CognitionTaskIcon"
+            return item
+            
         default:
             assertionFailure("WARNING! Unknown report identifier: \(reportIdentifier)")
             return nil
@@ -253,6 +262,12 @@ class HistoryDataManager : SBAReportManager {
             tappingItem.rightTapCount = (json[MCTHandSelection.right.rawValue] as? NSNumber)?.int16Value ?? 0
         }
         item.medicationTiming = json[kMedicationTimingKey] as? String
+        
+        // If this is a report for a cognition task, then set the title to whichever one was performed.
+        if reportIdentifier == .cognitionTask,
+            let title = json[kCognitionTaskTitle] as? String {
+            item.title = title
+        }
     }
 
     func mergeHeartSnapshotTasks(from reports: [SBAReport], in context: NSManagedObjectContext) throws {

--- a/mPower2/mPower2/SignInTaskViewController.swift
+++ b/mPower2/mPower2/SignInTaskViewController.swift
@@ -123,20 +123,10 @@ class SignInTaskViewController: RSDTaskViewController, SignInDelegate {
         signUp.phone!.number = phoneNumber
         signUp.phone!.regionCode = regionCode
         
-        var dataGroups = Set<String>()
-        // Assign the engagement data groups.
-        if let engagementGroups = (SBABridgeConfiguration.shared as? MP2BridgeConfiguration)?.studyBurst.randomEngagementGroups() {
-            dataGroups = dataGroups.union(engagementGroups)
-        }
-        
-        // Heart Snapshot tasks are only enabled for the Netherlands region
-        if (self.regionCode == SignInTaskViewController.NETHERLANDS_REGION_CODE) {
-            dataGroups = dataGroups.union(["show_heartsnapshot"])
-        }
-        
-        if (!dataGroups.isEmpty) {
-            signUp.dataGroups = dataGroups
-        }
+        // WARNING: syoung 12/09/2021 This appears to break things if you assign data groups
+        // on signup so that someone who is already signed up won't get the data groups that
+        // were previously assigned. So instead wait until the user is signed in using their
+        // phone number and set the data groups there.
         
         BridgeSDK.authManager.signUpStudyParticipant(signUp, completion: { (task, result, error) in
             guard error == nil else {

--- a/mPower2/mPower2/StudyBurstScheduleManager.swift
+++ b/mPower2/mPower2/StudyBurstScheduleManager.swift
@@ -1133,4 +1133,28 @@ class StudyBurstScheduleManager : TaskGroupScheduleManager {
         return (Localization.localizedString(titleKey),
                 Localization.localizedString(messageKey))
     }
+    
+    // MARK: Engagement groups
+        
+    func setEngagementGroupsIfNeeded() {
+        guard let participant = SBAParticipantManager.shared.studyParticipant,
+              let engagementDataGroups = studyBurst.engagementDataGroups
+        else {
+            return
+        }
+        
+        // Look to see if the data groups have not yet been assigned.
+        var dataGroups = participant.dataGroups ?? []
+        let hasAssigned = engagementDataGroups.reduce(true) { partialResult, groups in
+            partialResult && !dataGroups.intersection(groups).isEmpty
+        }
+        guard !hasAssigned, let engagementGroups = studyBurst.randomEngagementGroups()
+        else {
+            return
+        }
+        
+        dataGroups.formUnion(engagementGroups)
+        BridgeSDK.participantManager.updateDataGroups(withGroups: dataGroups) { _, _ in
+        }
+    }
 }

--- a/mPower2/mPower2/TodayScheduleManager.swift
+++ b/mPower2/mPower2/TodayScheduleManager.swift
@@ -127,6 +127,16 @@ class TodayHistoryScheduleManager : SBAScheduleManager {
         }
     }
     
+    override func didUpdateReports(with newReports: [SBAReport]) {
+        super.didUpdateReports(with: newReports)
+        offMainQueue.async {
+            let items = self.consolidateItems(self.scheduledActivities)
+            DispatchQueue.main.async {
+                self.items = items
+            }
+        }
+    }
+    
     /// Call through to super using an internal method that can be overridden by tests.
     func superDidUpdateScheduledActivities(from previousActivities: [SBBScheduledActivity]) {
         super.didUpdateScheduledActivities(from: previousActivities)
@@ -186,6 +196,11 @@ class TodayHistoryScheduleManager : SBAScheduleManager {
                         assertionFailure("Failed to decode the meds report. \(err)")
                         return 0
                     }
+                    
+                case .activities:
+                    return filteredSchedules.count + self.reports.filter {
+                        $0.identifier == RSDIdentifier.cognitionTask.identifier
+                    }.count
 
                 default:
                     return filteredSchedules.count
@@ -199,7 +214,8 @@ class TodayHistoryScheduleManager : SBAScheduleManager {
     }
     
     override open func reportQueries() -> [ReportQuery] {
-        return [ ReportQuery(reportKey: .triggersTask, queryType: .today, dateRange: nil),
+        return [ ReportQuery(reportKey: .cognitionTask, queryType: .today, dateRange: nil),
+                 ReportQuery(reportKey: .triggersTask, queryType: .today, dateRange: nil),
                  ReportQuery(reportKey: .symptomsTask, queryType: .today, dateRange: nil),
                  ReportQuery(reportKey: .medicationTask, queryType: .mostRecent, dateRange: nil)]
     }

--- a/mPower2/mPower2/mPower2.strings
+++ b/mPower2/mPower2/mPower2.strings
@@ -168,6 +168,7 @@
 "HISTORY_ITEM_TAP_TITLE" = "Tap Count";
 "HISTORY_ITEM_WALK_TITLE" = "Walk and Balance";
 "HISTORY_ITEM_TREMOR_TITLE" = "Tremor Test";
+"HISTORY_ITEM_COGNITION_TITLE" = "Cognition";
 "HISTORY_ITEM_HEART_SNAPSHOT_TITLE" = "Heart Snapshot";
 "HISTORY_ITEM_TAP_LEFT" = "Left Hand: %d";
 "HISTORY_ITEM_TAP_RIGHT" = "Right Hand: %d";

--- a/mPower2/mPower2Tests/StudyBurstOfflineTests.swift
+++ b/mPower2/mPower2Tests/StudyBurstOfflineTests.swift
@@ -42,7 +42,6 @@ class StudyBurstOfflineTests: XCTestCase {
     override func setUp() {
         RSDFactory.shared = MP2Factory()
         StudyBurstScheduleManager.flushDefaults()
-        MobileToolboxConfig.shared.mtbIdentifiers = []
     }
 
     override func tearDown() {

--- a/mPower2/mPower2Tests/StudyBurstTests.swift
+++ b/mPower2/mPower2Tests/StudyBurstTests.swift
@@ -40,9 +40,7 @@ import UserNotifications
 class StudyBurstManagerTests: StudyBurstTests {
     
     override func setUp() {
-        super.setUp()
-        
-        MobileToolboxConfig.shared.mtbIdentifiers = []
+        super.setUp()        
     }
     
     override func tearDown() {

--- a/mPower2/mPower2Tests/StudyBurstViewControllerTests.swift
+++ b/mPower2/mPower2Tests/StudyBurstViewControllerTests.swift
@@ -41,7 +41,6 @@ class StudyBurstViewControllerTests: StudyBurstTests {
     override func setUp() {
         super.setUp()
         StudyBurstScheduleManager.flushDefaults()
-        MobileToolboxConfig.shared.mtbIdentifiers = []
     }
     
     override func tearDown() {


### PR DESCRIPTION
This change adds the data groups *after* sign in rather than during sign up. Doing so allows checking for an existing participant and then *adding* the desired data groups to the ones set by the server. Previously, the data groups that were set on an existing user weren't getting picked up and the engagement groups were also getting muddled.

Additionally, I changed archive and upload to archive everything that gets included in the MobileToolboxApp b/c there was some confusion about what was actually needed from that archive.

Finally, this adds the cognition tasks to the history feed.